### PR TITLE
Fix for qbackingstore assert when using createWindowContainer as toolWindow

### DIFF
--- a/src/ToolWindowManager.cpp
+++ b/src/ToolWindowManager.cpp
@@ -649,7 +649,7 @@ void ToolWindowManager::restoreState(const QVariantMap &dataMap)
 
 ToolWindowManagerArea *ToolWindowManager::createArea(QWidget *owner)
 {
-  if(nullptr == owner)
+  if(owner == NULL)
   {
     owner = this;
   }

--- a/src/ToolWindowManager.cpp
+++ b/src/ToolWindowManager.cpp
@@ -227,9 +227,9 @@ void ToolWindowManager::moveToolWindows(QList<QWidget *> toolWindows,
   }
   else if(area.type() == NewFloatingArea)
   {
-    ToolWindowManagerArea *floatArea = createArea();
-    floatArea->addToolWindows(toolWindows);
     ToolWindowManagerWrapper *wrapper = new ToolWindowManagerWrapper(this, true);
+    ToolWindowManagerArea *floatArea = createArea(wrapper);
+    floatArea->addToolWindows(toolWindows);
     wrapper->layout()->addWidget(floatArea);
     wrapper->move(QCursor::pos());
     wrapper->updateTitle();
@@ -277,7 +277,7 @@ void ToolWindowManager::moveToolWindows(QList<QWidget *> toolWindows,
 
     delete item;
 
-    ToolWindowManagerArea *newArea = createArea();
+    ToolWindowManagerArea *newArea = createArea(splitter);
     newArea->addToolWindows(toolWindows);
 
     if(area.type() == TopWindowSide || area.type() == LeftWindowSide)
@@ -341,7 +341,7 @@ void ToolWindowManager::moveToolWindows(QList<QWidget *> toolWindows,
       {
         insertIndex++;
       }
-      ToolWindowManagerArea *newArea = createArea();
+      ToolWindowManagerArea *newArea = createArea(parentSplitter);
       newArea->addToolWindows(toolWindows);
       parentSplitter->insertWidget(insertIndex, newArea);
 
@@ -369,7 +369,7 @@ void ToolWindowManager::moveToolWindows(QList<QWidget *> toolWindows,
         splitter->setOrientation(Qt::Horizontal);
       }
 
-      ToolWindowManagerArea *newArea = createArea();
+      ToolWindowManagerArea *newArea = createArea(splitter);
 
       // inherit the size policy from the widget we are wrapping
       splitter->setSizePolicy(area.widget()->sizePolicy());
@@ -647,9 +647,14 @@ void ToolWindowManager::restoreState(const QVariantMap &dataMap)
   }
 }
 
-ToolWindowManagerArea *ToolWindowManager::createArea()
+ToolWindowManagerArea *ToolWindowManager::createArea(QWidget *owner)
 {
-  ToolWindowManagerArea *area = new ToolWindowManagerArea(this, 0);
+  if(nullptr == owner)
+  {
+    owner = this;
+  }
+
+  ToolWindowManagerArea *area = new ToolWindowManagerArea(this, owner);
   connect(area, SIGNAL(tabCloseRequested(int)), this, SLOT(tabCloseRequested(int)));
   return area;
 }
@@ -664,7 +669,6 @@ void ToolWindowManager::releaseToolWindow(QWidget *toolWindow)
   }
   previousTabWidget->removeTab(previousTabWidget->indexOf(toolWindow));
   toolWindow->hide();
-  toolWindow->setParent(0);
 }
 
 void ToolWindowManager::simplifyLayout()
@@ -860,7 +864,7 @@ QSplitter *ToolWindowManager::restoreSplitterState(const QVariantMap &savedData)
     }
     else if(itemType == QStringLiteral("area"))
     {
-      ToolWindowManagerArea *area = createArea();
+      ToolWindowManagerArea *area = createArea(splitter);
       area->restoreState(itemValue);
       splitter->addWidget(area);
     }

--- a/src/ToolWindowManager.h
+++ b/src/ToolWindowManager.h
@@ -343,7 +343,7 @@ protected:
    * \brief Creates new area and sets its default properties. You may reimplement
    * this function to change properties of all tab widgets used by this class.
    */
-  virtual ToolWindowManagerArea *createArea();
+  virtual ToolWindowManagerArea *createArea(QWidget *owner = nullptr);
 
 private slots:
   void tabCloseRequested(int index);

--- a/src/ToolWindowManager.h
+++ b/src/ToolWindowManager.h
@@ -343,7 +343,7 @@ protected:
    * \brief Creates new area and sets its default properties. You may reimplement
    * this function to change properties of all tab widgets used by this class.
    */
-  virtual ToolWindowManagerArea *createArea(QWidget *owner = nullptr);
+  virtual ToolWindowManagerArea *createArea(QWidget *owner = NULL);
 
 private slots:
   void tabCloseRequested(int index);


### PR DESCRIPTION
We discussed this issues briefly on discord. I'm not 100% sure, but this appears to fix the issue and not appear to cause any others.

Here was a video demonstrating the issue: https://www.youtube.com/watch?v=Uc4o0hKraoY&feature=youtu.be

Code to replicate issue in the example project: https://gist.github.com/playmer/88eb39a4c8c3c63274cda69ee336e9ff
(We don't draw to this window container in the example, so we expect some artifacting with regards to that)

Assert was: Q_ASSERT(window == topLevelWindow || topLevelWindow->isAncestorOf(window, QWindow::ExcludeTransients));

After this change, the artifacts on release seen in my engine video above, nor the asserts reappeared,

After some debugging, it seems the issue did have to do with parenting and how/when updates to the QBackingStore of the TooWindowManagerArea widget were being queued. The TooWindowManagerArea seemed like it was having a QBackingStore update queued while it wasn't parented correctly. When I gave it the parent on creation, this seemed to be resolved. I also needed to remove the toolWindow->setParent(0); in releaseToolWindow as it was similarly causing incorrect parenting issues with the QBackingStore.

I should also note that I've only tested this on Windows.